### PR TITLE
Switch DNS to point to AKS

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,6 +16,7 @@ withPipeline(type, product, component) {
   }
   enableDockerBuild()
   enableAksStagingDeployment()
+  disableLegacyDeployment()
   installCharts()
   enableSlackNotifications(channel)
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-806

### Change description ###

-  Although we have not deployed to ASE this change is required to switch DNS to point to AKS.

- Staging health check returns fine but prod slot is not reachable due to DNS not pointing to AKS.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```