### PR TITLE
Added app insights secret loading from vault config

### DIFF
--- a/charts/bulk-scan-payment-processor/Chart.yaml
+++ b/charts/bulk-scan-payment-processor/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A helm chart for bulk scan pay processor app
 name: bulk-scan-payment-processor
 home: https://github.com/hmcts/bulk-scan-payment-processor
-version: 0.0.9
+version: 0.1.0
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/bulk-scan-payment-processor/values.yaml
+++ b/charts/bulk-scan-payment-processor/values.yaml
@@ -17,6 +17,7 @@ java:
         - site-id-divorce
         - site-id-finrem
         - payments-queue-listen-connection-string
+        - app-insights-instrumentation-key
 bs-payment-processor:
   servicebus:
     enabled: false

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -10,3 +10,4 @@ spring:
         site-id-finrem: SITE_ID_FINREM
         payments-queue-listen-connection-string: PAYMENTS_QUEUE_READ_CONNECTION_STRING
         s2s-secret-payment-processor: S2S_SECRET
+        app-insights-instrumentation-key: azure.application-insights.instrumentation-key


### PR DESCRIPTION
### Change description ###

- This PR will need https://github.com/hmcts/bulk-scan-shared-infrastructure/pull/142 to get merged as it sets secret in vault.

- Previously app insights key was set in flux config as an env. This got removed when moving to bsp namespace. However this PR uses recommend approach and we need not set app insights instrumentation key in flux config of each environment.

- It will load the secret from vault and as an env var to be used by the application.

- It will be done only in AAT/PROD as we override the key vault config in preview.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
