### PR TITLE
Add common classes for talking to CCD and IDAM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,8 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.0.4', withoutSpringCloudContext
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.0.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '1.2.1'
+  compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.6.4'
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.1.3.RELEASE'
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.15'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/IntegrationContextInitializer.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/IntegrationContextInitializer.java
@@ -10,6 +10,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import uk.gov.hmcts.reform.idam.client.IdamApi;
 
 import static org.mockito.Mockito.mock;
 import static org.springframework.util.SocketUtils.findAvailableTcpPort;
@@ -35,4 +36,8 @@ public class IntegrationContextInitializer implements ApplicationContextInitiali
         return mock(IMessageReceiver.class);
     }
 
+    @Bean
+    public IdamApi idamApi() {
+        return mock(IdamApi.class);
+    }
 }

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -10,6 +10,18 @@ idam:
     url: *wiremock
   api:
     url: *wiremock
+  client:
+    id: 'bsp'
+    secret: 'idamclientsecret1'
+    redirect_uri: 'http://localhost/redirect-url'
+  users:
+    bulkscan:
+      username: user1@example.com
+      password: Password12
+
+core_case_data:
+  api:
+    url: *wiremock
 
 scheduling:
   task:

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/CcdAuthenticator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/CcdAuthenticator.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.ccd;
+
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+import java.util.function.Supplier;
+
+public class CcdAuthenticator {
+
+    private final UserDetails userDetails;
+    private final Supplier<String> serviceTokenSupplier;
+    private final Supplier<String> userTokenSupplier;
+
+    public CcdAuthenticator(
+        Supplier<String> serviceTokenSupplier,
+        UserDetails userDetails,
+        Supplier<String> userTokenSupplier
+    ) {
+        this.serviceTokenSupplier = serviceTokenSupplier;
+        this.userDetails = userDetails;
+        this.userTokenSupplier = userTokenSupplier;
+    }
+
+    public String getUserToken() {
+        return this.userTokenSupplier.get();
+    }
+
+    public String getServiceToken() {
+        return this.serviceTokenSupplier.get();
+    }
+
+    public UserDetails getUserDetails() {
+        return this.userDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/CcdAuthenticatorFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/CcdAuthenticatorFactory.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.ccd;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.config.JurisdictionToUserMapping;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+@Service
+@EnableConfigurationProperties(JurisdictionToUserMapping.class)
+public class CcdAuthenticatorFactory {
+
+    private final AuthTokenGenerator s2sTokenGenerator;
+    private final IdamClient idamClient;
+    private final JurisdictionToUserMapping users;
+
+    public CcdAuthenticatorFactory(
+        AuthTokenGenerator s2sTokenGenerator,
+        IdamClient idamClient,
+        JurisdictionToUserMapping users
+    ) {
+        this.s2sTokenGenerator = s2sTokenGenerator;
+        this.idamClient = idamClient;
+        this.users = users;
+    }
+
+    public CcdAuthenticator createForJurisdiction(String jurisdiction) {
+        Credential user = users.getUser(jurisdiction);
+        String userToken = idamClient.authenticateUser(user.getUsername(), user.getPassword());
+        UserDetails userDetails = idamClient.getUserDetails(userToken);
+
+        return new CcdAuthenticator(
+            s2sTokenGenerator::generate,
+            userDetails,
+            () -> userToken
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/Credential.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/Credential.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.ccd;
+
+public class Credential {
+    private final String username;
+    private final String password;
+
+    public Credential(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/JurisdictionToUserMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/JurisdictionToUserMapping.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.ccd.Credential;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.exception.NoUserConfiguredException;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Map.Entry;
+import static java.util.stream.Collectors.toMap;
+
+@ConfigurationProperties(prefix = "idam")
+public class JurisdictionToUserMapping {
+
+    private Map<String, Credential> users = new HashMap<>();
+
+    public void setUsers(Map<String, Map<String, String>> users) {
+        this.users = users
+            .entrySet()
+            .stream()
+            .map(this::createEntry)
+            .collect(toMap(Entry::getKey, Entry::getValue));
+    }
+
+    public Map<String, Credential> getUsers() {
+        return users;
+    }
+
+    private Entry<String, Credential> createEntry(Entry<String, Map<String, String>> entry) {
+        String key = entry.getKey().toLowerCase(Locale.getDefault());
+        Credential cred = new Credential(entry.getValue().get("username"), entry.getValue().get("password"));
+
+        return new AbstractMap.SimpleEntry<>(key, cred);
+    }
+
+    public Credential getUser(String jurisdiction) {
+        return users.computeIfAbsent(jurisdiction.toLowerCase(), this::throwNotFound);
+    }
+
+    private Credential throwNotFound(String jurisdiction) {
+        throw new NoUserConfiguredException(jurisdiction);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/exception/NoUserConfiguredException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/exception/NoUserConfiguredException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.exception;
+
+public class NoUserConfiguredException extends RuntimeException {
+    public NoUserConfiguredException(String jurisdiction) {
+        super("No user configured for jurisdiction: " + jurisdiction);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,14 @@ idam:
     url: ${S2S_URL:http://localhost:4552}
     secret: ${S2S_SECRET:AAAAAAAAAAAAAAAA}
     name: ${S2S_NAME:bulk_scan_payments_processor}
+  api:
+    url: ${IDAM_API_URL}
+  client:
+    id: 'bsp'
+    secret: ${IDAM_CLIENT_SECRET}
+    redirect_uri: ${IDAM_CLIENT_REDIRECT_URL}
+  users:
+    # defined in IDAM_USERS_... env vars
 
 scheduling:
   task:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/CcdAuthenticatorFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/CcdAuthenticatorFactoryTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.ccd;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.config.JurisdictionToUserMapping;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class CcdAuthenticatorFactoryTest {
+
+    @Mock
+    private AuthTokenGenerator tokenGenerator;
+    @Mock
+    private IdamClient idamClient;
+    @Mock
+    private JurisdictionToUserMapping users;
+
+    private CcdAuthenticatorFactory service;
+
+    @BeforeEach
+    void before() {
+        service = new CcdAuthenticatorFactory(tokenGenerator, idamClient, users);
+    }
+
+    @Test
+    void should_successfully_return_authInfo() {
+        // given
+        String jurisdiction = "jurisdiction1";
+        String serviceToken = "serviceToken1";
+        Credential credentials = mock(Credential.class);
+        String userToken = "userToken1";
+        UserDetails userDetails = mock(UserDetails.class);
+
+        given(users.getUser(eq(jurisdiction))).willReturn(credentials);
+        given(tokenGenerator.generate()).willReturn(serviceToken);
+        given(idamClient.authenticateUser(any(), any())).willReturn(userToken);
+        given(idamClient.getUserDetails(userToken)).willReturn(userDetails);
+
+        // when
+        CcdAuthenticator authenticator = service.createForJurisdiction(jurisdiction);
+
+        // then
+        assertThat(authenticator.getServiceToken()).isEqualTo(serviceToken);
+        assertThat(authenticator.getUserToken()).isEqualTo(userToken);
+        assertThat(authenticator.getUserDetails()).isEqualTo(userDetails);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/JurisdictionToUserMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/JurisdictionToUserMappingTest.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.ccd.Credential;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.exception.NoUserConfiguredException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+@ExtendWith(SpringExtension.class)
+@Import(JurisdictionToUserMapping.class)
+@EnableConfigurationProperties
+@TestPropertySource(properties = {
+    "idam.users.bulkscan.username=user@example.com",
+    "idam.users.bulkscan.password=password1"
+})
+public class JurisdictionToUserMappingTest {
+
+    @Autowired
+    private JurisdictionToUserMapping mapping;
+
+    @Test
+    public void should_parse_up_the_properties_into_map() {
+        Credential credentials = mapping.getUser("BULKSCAN");
+        assertThat(credentials.getPassword()).isEqualTo("password1");
+        assertThat(credentials.getUsername()).isEqualTo("user@example.com");
+    }
+
+    @Test
+    public void should_throw_exception_when_user_not_found() {
+        Throwable throwable = catchThrowable(() -> mapping.getUser("nonexisting"));
+
+        assertThat(throwable)
+            .isInstanceOf(NoUserConfiguredException.class)
+            .hasMessage("No user configured for jurisdiction: nonexisting");
+    }
+
+    @Test
+    public void should_throw_exception_if_none_configured() {
+        Throwable throwable = catchThrowable(
+            () -> new JurisdictionToUserMapping().getUser("NONE")
+        );
+
+        assertThat(throwable)
+            .isInstanceOf(NoUserConfiguredException.class)
+            .hasMessage("No user configured for jurisdiction: none");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-810

### Change description ###

Add common classes for talking to CCD and IDAM, to be used when updating exception record in CCD. Please note that these classes are almost a copy from the orchestrator. They're planned to be extracted into a separate library, so I want to keep them consistent between these two projects.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
