### PR TITLE
remove envelope_id and service from update payment 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/PaymentMessageParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/PaymentMessageParser.java
@@ -63,7 +63,7 @@ public class PaymentMessageParser {
 
     private void logMessageParsed(CreatePaymentMessage payment) {
         LOGGER.info(
-            "Parsed Payment message, Envelope ID: {}, CCD Case Number: {}, Is Exception Record: {}, Jurisdiction: {}, "
+            "Parsed Create Payment message, Envelope ID: {}, CCD Case Number: {}, Is Exception Record: {}, Jurisdiction: {}, "
                 + "PO Box: {}, Service {}, Document Control Numbers : {}",
             payment.envelopeId,
             payment.ccdReference,
@@ -77,11 +77,9 @@ public class PaymentMessageParser {
 
     private void logMessageParsed(UpdatePaymentMessage payment) {
         LOGGER.info(
-            "Parsed Payment message, Envelope ID: {}, Jurisdiction: {}, "
-                + "Service: {}, Exception Record Ref: {}, newCaseRef:{}",
-            payment.envelopeId,
+            "Parsed update payment message, Jurisdiction: {}, "
+                + "Exception Record Ref: {}, newCaseRef:{}",
             payment.jurisdiction,
-            payment.service,
             payment.exceptionRecordRef,
             payment.newCaseRef
         );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/PaymentMessageProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/PaymentMessageProcessor.java
@@ -120,9 +120,10 @@ public class PaymentMessageProcessor {
             payment = paymentMessageParser.parseUpdateMessage(message.getMessageBody());
             paymentMessageHandler.updatePaymentCaseReference(payment);
             log.info(
-                "Processed update payment message with ID {}. Envelope ID: {}",
+                "Processed update payment message with ID {}. Exception Record Ref: {}, New case ref ID: {}",
                 message.getMessageId(),
-                payment.envelopeId
+                payment.exceptionRecordRef,
+                payment.newCaseRef
             );
             return new MessageProcessingResult(SUCCESS);
         } catch (InvalidMessageException ex) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/handler/PaymentMessageHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/handler/PaymentMessageHandler.java
@@ -63,8 +63,7 @@ public class PaymentMessageHandler {
         CaseReferenceRequest request = new CaseReferenceRequest(paymentMessage.newCaseRef);
 
         log.info(
-            "Sending payment update case reference request, envelope id: {}, case ref: {}, exception ref: {}",
-            paymentMessage.envelopeId,
+            "Sending payment update case reference request, case ref: {}, exception ref: {}",
             request.ccdCaseNumber,
             paymentMessage.exceptionRecordRef
         );
@@ -76,8 +75,7 @@ public class PaymentMessageHandler {
         );
 
         log.info(
-            "Payment update response from PayHub, envelope id: {}, http status: {} ",
-            paymentMessage.envelopeId,
+            "Successful Payment update response from PayHub, http status: {} ",
             response.getStatusCode()
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/model/UpdatePaymentMessage.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/model/UpdatePaymentMessage.java
@@ -4,22 +4,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class UpdatePaymentMessage {
 
-    public final String envelopeId;
     public final String jurisdiction;
-    public final String service;
     public final String exceptionRecordRef;
     public final String newCaseRef;
 
     public UpdatePaymentMessage(
-        @JsonProperty(value = "envelope_id", required = true) String envelopeId,
         @JsonProperty(value = "jurisdiction", required = true) String jurisdiction,
-        @JsonProperty(value = "service", required = true) String service,
         @JsonProperty(value = "exception_record_ref", required = true) String exceptionRecordRef,
         @JsonProperty(value = "new_case_ref", required = true) String newCaseRef
     ) {
-        this.envelopeId = envelopeId;
         this.jurisdiction = jurisdiction;
-        this.service = service;
         this.exceptionRecordRef = exceptionRecordRef;
         this.newCaseRef = newCaseRef;
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/data/producer/SamplePaymentMessageData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/data/producer/SamplePaymentMessageData.java
@@ -36,17 +36,13 @@ public final class SamplePaymentMessageData {
     }
 
     public static byte[] updatePaymentMessageJsonAsByte(
-        String envelopeId,
         String jurisdiction,
-        String service,
         String exceptionRecordRef,
         String newCaseRef
     ) throws JSONException {
 
         return new JSONObject()
-            .put("envelope_id", envelopeId)
             .put("jurisdiction", jurisdiction)
-            .put("service", service)
             .put("exception_record_ref", exceptionRecordRef)
             .put("new_case_ref", newCaseRef)
             .toString().getBytes();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/PaymentMessageProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/PaymentMessageProcessorTest.java
@@ -139,8 +139,6 @@ public class PaymentMessageProcessorTest {
     public void should_complete_update_message_when_processing_is_successful() throws Exception {
         // given
         IMessage validMessage = getValidUpdateMessage(
-            "env-12312",
-            "PROBATE",
             "PROBATE",
             "excp-ref-9999",
             "new-case-ref-12312"
@@ -149,8 +147,6 @@ public class PaymentMessageProcessorTest {
         given(messageReceiver.receive()).willReturn(validMessage);
 
         willReturn(new UpdatePaymentMessage(
-            "env-12312",
-            "PROBATE",
             "PROBATE",
             "excp-ref-9999",
             "new-case-ref-12312"
@@ -284,16 +280,12 @@ public class PaymentMessageProcessorTest {
     @Test
     public void should_not_dead_letter_the_update_message_when_recoverable_failure() throws Exception {
         willReturn(getValidUpdateMessage(
-            "env-12312",
-            "PROBATE",
             "PROBATE",
             "excp-ref-9999",
             "new-case-ref-12312"
         )).given(messageReceiver).receive();
 
         willReturn(new UpdatePaymentMessage(
-            "env-12312",
-            "PROBATE",
             "PROBATE",
             "excp-ref-9999",
             "new-case-ref-12312"
@@ -349,8 +341,6 @@ public class PaymentMessageProcessorTest {
     public void should_dead_letter_update_message_when_recoverable_failure_but_delivery_maxed() throws Exception {
         // given
         IMessage validMessage = getValidUpdateMessage(
-            "env-12312",
-            "PROBATE",
             "PROBATE",
             "excp-ref-9999",
             "new-case-ref-12312"
@@ -359,8 +349,6 @@ public class PaymentMessageProcessorTest {
         given(messageReceiver.receive()).willReturn(validMessage);
 
         willReturn(new UpdatePaymentMessage(
-            "env-12312",
-            "PROBATE",
             "PROBATE",
             "excp-ref-9999",
             "new-case-ref-12312"
@@ -409,9 +397,7 @@ public class PaymentMessageProcessorTest {
     }
 
     private IMessage getValidUpdateMessage(
-        String envelopeId,
         String jurisdiction,
-        String service,
         String exceptionRecordRef,
         String newCaseRef
     ) throws JSONException {
@@ -422,9 +408,7 @@ public class PaymentMessageProcessorTest {
                 MessageBody.fromBinaryData(
                     ImmutableList.of(
                         updatePaymentMessageJsonAsByte(
-                            envelopeId,
                             jurisdiction,
-                            service,
                             exceptionRecordRef,
                             newCaseRef
                         )

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/PaymentMessageHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/PaymentMessageHandlerTest.java
@@ -73,9 +73,7 @@ public class PaymentMessageHandlerTest {
     public void should_call_payhub_api_to_assign_case_ref() {
         // given
         UpdatePaymentMessage message = new UpdatePaymentMessage(
-            "env-id-12321",
-            "Divorece",
-            "Finrem",
+            "Divorce",
             "exp-21321",
             "cas-ref-9999"
         );
@@ -103,9 +101,7 @@ public class PaymentMessageHandlerTest {
     public void should_throw_exception_if_payhub_api_assign_case_ref_fails() {
         // given
         UpdatePaymentMessage message = new UpdatePaymentMessage(
-            "env-id-12321",
-            "Divorece",
-            "Finrem",
+            "Divorce",
             "exp-21321",
             "cas-ref-9999"
         );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/PaymentMessageParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/service/servicebus/PaymentMessageParserTest.java
@@ -61,9 +61,7 @@ public class PaymentMessageParserTest {
     @Test
     public void should_return_valid_updatePaymentMessage_when_queue_message_is_valid() throws JSONException {
         UpdatePaymentMessage expected = new UpdatePaymentMessage(
-            "envelopeId",
             "Probate",
-            "probate",
             "322131",
             "99999"
         );
@@ -74,9 +72,7 @@ public class PaymentMessageParserTest {
                     fromBinaryData(
                         ImmutableList.of(
                             getUpdatePaymentMessageJsonString(
-                                "envelopeId",
                                 "Probate",
-                                "probate",
                                 "322131",
                                 "99999"
                             ).getBytes()
@@ -107,17 +103,13 @@ public class PaymentMessageParserTest {
     }
 
     private static String getUpdatePaymentMessageJsonString(
-        String envelopeId,
         String jurisdiction,
-        String service,
         String exceptionRecordRef,
         String newCaseRef
     ) throws JSONException {
 
         return new JSONObject()
-            .put("envelope_id", envelopeId)
             .put("jurisdiction", jurisdiction)
-            .put("service", service)
             .put("exception_record_ref", exceptionRecordRef)
             .put("new_case_ref", newCaseRef)
             .toString();


### PR DESCRIPTION

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable)

https://tools.hmcts.net/jira/browse/BPS-766

### Change description

remove envelope_id and service from update payment as orchestrator can not provide these fields

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
