### PR TITLE
Create a service that returns IDAM user's credentials based on jurisdiction

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/Credential.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/ccd/Credential.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.ccd;
+
+public class Credential {
+    private final String username;
+    private final String password;
+
+    public Credential(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/JurisdictionToUserMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/JurisdictionToUserMapping.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.ccd.Credential;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.exception.NoUserConfiguredException;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Map.Entry;
+import static java.util.stream.Collectors.toMap;
+
+@ConfigurationProperties(prefix = "idam")
+public class JurisdictionToUserMapping {
+
+    private Map<String, Credential> users = new HashMap<>();
+
+    public void setUsers(Map<String, Map<String, String>> users) {
+        this.users = users
+            .entrySet()
+            .stream()
+            .map(this::createEntry)
+            .collect(toMap(Entry::getKey, Entry::getValue));
+    }
+
+    public Map<String, Credential> getUsers() {
+        return users;
+    }
+
+    private Entry<String, Credential> createEntry(Entry<String, Map<String, String>> entry) {
+        String key = entry.getKey().toLowerCase(Locale.getDefault());
+        Credential cred = new Credential(entry.getValue().get("username"), entry.getValue().get("password"));
+
+        return new AbstractMap.SimpleEntry<>(key, cred);
+    }
+
+    public Credential getUser(String jurisdiction) {
+        return users.computeIfAbsent(jurisdiction.toLowerCase(), this::throwNotFound);
+    }
+
+    private Credential throwNotFound(String jurisdiction) {
+        throw new NoUserConfiguredException(jurisdiction);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/exception/NoUserConfiguredException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/exception/NoUserConfiguredException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.exception;
+
+public class NoUserConfiguredException extends RuntimeException {
+    public NoUserConfiguredException(String jurisdiction) {
+        super("No user configured for jurisdiction: " + jurisdiction);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/JurisdictionToUserMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/config/JurisdictionToUserMappingTest.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.ccd.Credential;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.exception.NoUserConfiguredException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+@ExtendWith(SpringExtension.class)
+@Import(JurisdictionToUserMapping.class)
+@EnableConfigurationProperties
+@TestPropertySource(properties = {
+    "idam.users.bulkscan.username=user@example.com",
+    "idam.users.bulkscan.password=password1"
+})
+public class JurisdictionToUserMappingTest {
+
+    @Autowired
+    private JurisdictionToUserMapping mapping;
+
+    @Test
+    public void should_parse_up_the_properties_into_map() {
+        Credential credentials = mapping.getUser("BULKSCAN");
+        assertThat(credentials.getPassword()).isEqualTo("password1");
+        assertThat(credentials.getUsername()).isEqualTo("user@example.com");
+    }
+
+    @Test
+    public void should_throw_exception_when_user_not_found() {
+        Throwable throwable = catchThrowable(() -> mapping.getUser("nonexisting"));
+
+        assertThat(throwable)
+            .isInstanceOf(NoUserConfiguredException.class)
+            .hasMessage("No user configured for jurisdiction: nonexisting");
+    }
+
+    @Test
+    public void should_throw_exception_if_none_configured() {
+        Throwable throwable = catchThrowable(
+            () -> new JurisdictionToUserMapping().getUser("NONE")
+        );
+
+        assertThat(throwable)
+            .isInstanceOf(NoUserConfiguredException.class)
+            .hasMessage("No user configured for jurisdiction: none");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-810

### Change description ###

Create a service that returns IDAM user's credentials based on jurisdiction. This service is a copy of an existing one in bulk-scan-orchestrator. I want to keep them the same, keeping in mind that authentication tools are going to be extracted into a separate library and this mapping may be a part of that.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
