### PR TITLE
Bump chart version to 0.1.4

### DIFF
--- a/charts/bulk-scan-payment-processor/Chart.yaml
+++ b/charts/bulk-scan-payment-processor/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A helm chart for bulk scan pay processor app
 name: bulk-scan-payment-processor
 home: https://github.com/hmcts/bulk-scan-payment-processor
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net


### PR DESCRIPTION
### Change description ###

Bump chart version. This should have been done as part of https://github.com/hmcts/bulk-scan-payment-processor/pull/122, which changes configuration.

Corresponding change in cnp-flux-config: https://github.com/hmcts/cnp-flux-config/pull/1140

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
