### PR TITLE
Fix queue connection string settings

### DIFF
--- a/charts/bulk-scan-payment-processor/Chart.yaml
+++ b/charts/bulk-scan-payment-processor/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A helm chart for bulk scan pay processor app
 name: bulk-scan-payment-processor
 home: https://github.com/hmcts/bulk-scan-payment-processor
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/bulk-scan-payment-processor/values.yaml
+++ b/charts/bulk-scan-payment-processor/values.yaml
@@ -22,6 +22,7 @@ java:
         - site-id-finrem
         - payments-queue-listen-connection-string
         - app-insights-instrumentation-key
+        - payments-queue-listen-connection-string
         - idam-client-secret
         - idam-users-bulkscan-username
         - idam-users-bulkscan-password

--- a/charts/bulk-scan-payment-processor/values.yaml
+++ b/charts/bulk-scan-payment-processor/values.yaml
@@ -22,7 +22,6 @@ java:
         - site-id-finrem
         - payments-queue-listen-connection-string
         - app-insights-instrumentation-key
-        - payments-queue-listen-connection-string
         - idam-client-secret
         - idam-users-bulkscan-username
         - idam-users-bulkscan-password

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -11,6 +11,7 @@ spring:
         s2s-secret-payment-processor: S2S_SECRET
         app-insights-instrumentation-key: azure.application-insights.instrumentation-key
         idam-client-secret: IDAM_CLIENT_SECRET
+        payments-queue-listen-connection-string: PAYMENTS_QUEUE_READ_CONNECTION_STRING
         idam-users-bulkscan-username: idam.users.bulkscan.username
         idam-users-bulkscan-password: idam.users.bulkscan.password
         idam-users-cmc-username: idam.users.cmc.username


### PR DESCRIPTION
### Change description ###

Fix queue connection string settings. Currently, doesn't get set outside preview.

Related cnp-flux-config pr: https://github.com/hmcts/cnp-flux-config/pull/1145

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
