### PR TITLE
Fix terraform config

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -27,21 +27,21 @@ locals {
   users_secret_names = "${values(local.supported_users)}"
 
   users_usernames_settings = "${zipmap(
-                                    formatlist("IDAM_USERS_%s_USERNAME", keys(local.supported_users)),
-                                    data.azurerm_key_vault_secret.idam_users_usernames.*.value
-                                )}"
+    formatlist("IDAM_USERS_%s_USERNAME", keys(local.supported_users)),
+    data.azurerm_key_vault_secret.idam_users_usernames.*.value
+  )}"
 
   users_passwords_settings = "${zipmap(
-                                    formatlist("IDAM_USERS_%s_PASSWORD", keys(local.supported_users)),
-                                    data.azurerm_key_vault_secret.idam_users_passwords.*.value
-                                )}"
+    formatlist("IDAM_USERS_%s_PASSWORD", keys(local.supported_users)),
+    data.azurerm_key_vault_secret.idam_users_passwords.*.value
+  )}"
 
   payhub_site_id_secret_names = "${values(var.payhub_sites)}"
 
   payhub_site_settings = "${zipmap(
-                                    keys(var.payhub_sites),
-                                    data.azurerm_key_vault_secret.payhub_site_ids.*.value
-                                )}"
+    keys(var.payhub_sites),
+    data.azurerm_key_vault_secret.payhub_site_ids.*.value
+  )}"
 
   core_app_settings = {
     PAY_HUB_URL                           = "http://ccpay-bulkscanning-api-${var.env}.service.core-compute-${var.env}.internal"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -17,15 +17,6 @@ locals {
     CMC      = "idam-users-cmc"
   }
 
-  # maps the names of environment variables representing PayHub site IDs to key vault secret names
-  payhub_sites = {
-    SITE_ID_PROBATE = "site-id-probate"
-    SITE_ID_DIVORCE = "site-id-divorce"
-    SITE_ID_FINREM  = "site-id-finrem"
-    # site-id-bulkscan secret should not be defined in prod
-    SITE_ID_BULKSCAN = "site-id-bulkscan"
-  }
-
   all_services          = "${keys(local.users)}"
   supported_user_keys   = "${matchkeys(local.all_services, local.all_services, var.supported_services)}"
   supported_user_values = "${matchkeys(values(local.users), local.all_services, var.supported_services)}"
@@ -45,10 +36,10 @@ locals {
                                     data.azurerm_key_vault_secret.idam_users_passwords.*.value
                                 )}"
 
-  payhub_site_id_secret_names = "${values(local.payhub_sites)}"
+  payhub_site_id_secret_names = "${values(var.payhub_sites)}"
 
   payhub_site_settings = "${zipmap(
-                                    keys(local.payhub_sites),
+                                    keys(var.payhub_sites),
                                     data.azurerm_key_vault_secret.payhub_site_ids.*.value
                                 )}"
 
@@ -136,7 +127,7 @@ data "azurerm_key_vault_secret" "idam_users_passwords" {
 }
 
 data "azurerm_key_vault_secret" "payhub_site_ids" {
-  count        = "${length(local.payhub_sites)}"
+  count        = "${length(var.payhub_sites)}"
   key_vault_id = "${data.azurerm_key_vault.bulk_scan_key_vault.id}"
   name         = "${local.payhub_site_id_secret_names[count.index]}"
 }

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,0 +1,5 @@
+payhub_sites = {
+  SITE_ID_PROBATE = "site-id-probate"
+  SITE_ID_DIVORCE = "site-id-divorce"
+  SITE_ID_FINREM  = "site-id-finrem"
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -50,6 +50,17 @@ variable "supported_services" {
   description = "Services to be supported by Bulk Scan in the given environment. Bulk Scan will only be able to map these ones to IDAM user credentials"
   default     = ["SSCS", "BULKSCAN", "PROBATE", "DIVORCE", "FINREM", "CMC"]
 }
+variable "payhub_sites" {
+  type = "map"
+  description = "maps the names of environment variables representing PayHub site IDs to key vault secret names"
+  default = {
+    SITE_ID_PROBATE = "site-id-probate"
+    SITE_ID_DIVORCE = "site-id-divorce"
+    SITE_ID_FINREM  = "site-id-finrem"
+    # site-id-bulkscan secret should not be defined in prod
+    SITE_ID_BULKSCAN = "site-id-bulkscan"
+  }
+}
 
 variable "enable_ase" {
   default = false

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -51,7 +51,7 @@ variable "supported_services" {
   default     = ["SSCS", "BULKSCAN", "PROBATE", "DIVORCE", "FINREM", "CMC"]
 }
 variable "payhub_sites" {
-  type = "map"
+  type        = "map"
   description = "maps the names of environment variables representing PayHub site IDs to key vault secret names"
   default = {
     SITE_ID_PROBATE = "site-id-probate"


### PR DESCRIPTION
### Change description ###

After applying #165 master pipeline has broken and cannot be released to production due to clearly stated option "bulkscan site id must not be configured for production". Which isn't in fact.

Solution: moving local terraform definition to variables and overriding for production.

P.S. Applied `terraform fmt` for `users_usernames_settings` and `users_passwords_settings` because entirely PR is not too complex nor big

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
