### PR TITLE
Remove obsolete build flag

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -74,7 +74,6 @@ withPipeline(type, product, component) {
     builder.gradle('integration')
   }
 
-  enableDockerBuild()
   enableAksStagingDeployment()
   disableLegacyDeployment()
   installCharts()


### PR DESCRIPTION
After revent platform change:
>enableDockerBuild() is deprecated and no longer does anything, please remove this flag before the pipeline starts failing., This configuration will stop working by 18/02/2020 00:00 AM ( in 6 days )