### PR TITLE
Remove redundant dependency management for tomcat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,10 +151,6 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: '3.2.4') {
       entry 'mockito-core'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.30') {
-      entry 'tomcat-embed-core'
-      entry 'tomcat-embed-websocket'
-    }
   }
 }
 


### PR DESCRIPTION
### Change description ###

Vulnerabilities already solved with latest spring boot updates. Management is redundant now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
