### PR TITLE
Update test framework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ dependencyManagement {
     dependencySet(group: 'com.google.guava', version: '29.0-jre') {
       entry 'guava'
     }
-    dependencySet(group: 'org.mockito', version: '3.3.3') {
+    dependencySet(group: 'org.mockito', version: '3.4.0') {
       entry 'mockito-core'
     }
   }
@@ -211,7 +211,7 @@ dependencies {
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
   testCompile group: 'org.junit.platform', name: 'junit-platform-commons', version: versions.junitPlatform
   testCompile group: 'org.junit.platform', name: 'junit-platform-engine', version: versions.junitPlatform
-  testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.3.3'
+  testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.4.0'
   testCompile group: 'org.awaitility', name: 'awaitility', version: '4.0.3'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', withoutJunit4

--- a/build.gradle
+++ b/build.gradle
@@ -216,7 +216,7 @@ dependencies {
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', withoutJunit4
 
-  integrationTestCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.26.3', withoutJunit4
+  integrationTestCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.27.1', withoutJunit4
 
   integrationTestCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '2.2.3.RELEASE', withoutMockitoStandAlone
 

--- a/build.gradle
+++ b/build.gradle
@@ -164,8 +164,8 @@ repositories {
 }
 
 def versions = [
-  junit           : '5.6.1',
-  junitPlatform   : '1.6.1',
+  junit           : '5.6.2',
+  junitPlatform   : '1.6.2',
   reformLogging   : '5.1.6',
   springBoot      : springBoot.class.package.implementationVersion,
   springfoxSwagger: '2.9.2'


### PR DESCRIPTION
### Change description ###

When commented on one of the PRs (#246 or #247) I didn't realise it could've failed due to GitHub outage. Nevertheless - good to quickly run through test framework deps now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
