### PR TITLE
Replace servicebus connection string with access key and namespace in functional tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -28,7 +28,7 @@ def nonPreviewSecrets = [
     secret('idam-users-bulkscan-username', 'IDAM_USERS_BULKSCAN_USERNAME'),
     secret('idam-users-bulkscan-password', 'IDAM_USERS_BULKSCAN_PASSWORD'),
     secret('idam-client-secret', 'IDAM_CLIENT_SECRET'),
-    secret('payments-queue-send-connection-string', 'PAYMENTS_QUEUE_WRITE_CONNECTION_STRING')
+    secret('payments-queue-send-shared-access-key', 'PAYMENTS_QUEUE_WRITE_ACCESS_KEY') // needs staging?
   ]
 ]
 
@@ -49,6 +49,8 @@ withPipeline(type, product, component) {
     env.CORE_CASE_DATA_API_URL = 'http://ccd-data-store-api-aat.service.core-compute-aat.internal'
     env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
     env.IDAM_CLIENT_REDIRECT_URI = 'https://bulk-scan-orchestrator-aat.service.core-compute-aat.internal/oauth2/callback'
+    env.PAYMENTS_QUEUE_NAMESPACE = "bulk-scan-servicebus-aat" // needs staging?
+    env.PAYMENTS_QUEUE_WRITE_ACCESS_KEY_NAME = "SendSharedAccessKey"
   }
 
   before('smoketest:preview') {
@@ -62,8 +64,9 @@ withPipeline(type, product, component) {
       def kubectl = new Kubectl(this, subscription, namespace)
       kubectl.login()
 
-      def sbConnectionStr = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.connectionString}")
-      env.PAYMENTS_QUEUE_WRITE_CONNECTION_STRING = "${sbConnectionStr};EntityPath=payments"
+      env.PAYMENTS_QUEUE_NAMESPACE = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.namespaceName}")
+      env.PAYMENTS_QUEUE_WRITE_ACCESS_KEY = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.primaryKey}")
+      env.PAYMENTS_QUEUE_WRITE_ACCESS_KEY_NAME = "RootManageSharedAccessKey"
     }
   }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/FunctionalQueueConfig.java
@@ -7,20 +7,24 @@ import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 import static org.mockito.Mockito.mock;
 
+@Configuration
 @Profile("functional")
 public class FunctionalQueueConfig {
 
-    @Value("${azure.servicebus.payments.write-connection-string}")
-    private String paymentsQueueWriteConnectionString;
-
     @Bean("payments")
-    public QueueClient paymentsWriteClient() throws ServiceBusException, InterruptedException {
+    public QueueClient paymentsWriteClient(
+        @Value("${azure.servicebus.payments.namespace}") String namespace,
+        @Value("${azure.servicebus.payments.write-access-key}") String accessKey,
+        @Value("${azure.servicebus.payments.write-access-key-name}") String accessKeyName,
+        @Value("${azure.servicebus.payments.queue-name}") String queueName
+    ) throws ServiceBusException, InterruptedException {
         return new QueueClient(
-            new ConnectionStringBuilder(paymentsQueueWriteConnectionString),
+            new ConnectionStringBuilder(namespace, queueName, accessKeyName, accessKey),
             ReceiveMode.PEEKLOCK
         );
     }

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -9,7 +9,9 @@ spring:
 azure:
   servicebus:
     payments:
-      write-connection-string: ${PAYMENTS_QUEUE_WRITE_CONNECTION_STRING}
+      namespace: ${PAYMENTS_QUEUE_NAMESPACE}
+      write-access-key: ${PAYMENTS_QUEUE_WRITE_ACCESS_KEY}
+      write-access-key-name: ${PAYMENTS_QUEUE_WRITE_ACCESS_KEY_NAME}
       queue-name: payments
 
 idam:


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Improve the way Service Bus clients are created](https://tools.hmcts.net/jira/browse/BPS-771)

### Change description ###

Last in chain - completely getting rid of connection strings

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
