### PR TITLE
Introduce staging queue access for aat pipeline

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -28,7 +28,7 @@ def nonPreviewSecrets = [
     secret('idam-users-bulkscan-username', 'IDAM_USERS_BULKSCAN_USERNAME'),
     secret('idam-users-bulkscan-password', 'IDAM_USERS_BULKSCAN_PASSWORD'),
     secret('idam-client-secret', 'IDAM_CLIENT_SECRET'),
-    secret('payments-queue-send-shared-access-key', 'PAYMENTS_QUEUE_WRITE_ACCESS_KEY') // needs staging?
+    secret('payments-staging-queue-send-shared-access-key', 'PAYMENTS_QUEUE_WRITE_ACCESS_KEY')
   ]
 ]
 
@@ -49,7 +49,7 @@ withPipeline(type, product, component) {
     env.CORE_CASE_DATA_API_URL = 'http://ccd-data-store-api-aat.service.core-compute-aat.internal'
     env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
     env.IDAM_CLIENT_REDIRECT_URI = 'https://bulk-scan-orchestrator-aat.service.core-compute-aat.internal/oauth2/callback'
-    env.PAYMENTS_QUEUE_NAMESPACE = "bulk-scan-servicebus-aat" // needs staging?
+    env.PAYMENTS_QUEUE_NAMESPACE = "bulk-scan-servicebus-aat"
     env.PAYMENTS_QUEUE_WRITE_ACCESS_KEY_NAME = "SendSharedAccessKey"
   }
 

--- a/charts/bulk-scan-payment-processor/Chart.yaml
+++ b/charts/bulk-scan-payment-processor/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A helm chart for bulk scan pay processor app
 name: bulk-scan-payment-processor
 home: https://github.com/hmcts/bulk-scan-payment-processor
-version: 0.2.2
+version: 0.2.3
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/bulk-scan-payment-processor/values.aat.template.yaml
+++ b/charts/bulk-scan-payment-processor/values.aat.template.yaml
@@ -1,4 +1,6 @@
 java:
+  environment:
+    PAYMENTS_QUEUE_NAME: payments-staging
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}

--- a/charts/bulk-scan-payment-processor/values.preview.template.yaml
+++ b/charts/bulk-scan-payment-processor/values.preview.template.yaml
@@ -11,6 +11,7 @@ java:
     PAYMENTS_QUEUE_ACCESS_KEY_LISTEN_NAME: "RootManageSharedAccessKey"
     PAYMENTS_QUEUE_ACCESS_KEY_SEND_NAME: "RootManageSharedAccessKey"
     PAYMENTS_QUEUE_READ_ACCESS_KEY: "$(SB_ACCESS_KEY)"
+    PAYMENTS_QUEUE_NAME: "payments-staging"
     PAYMENTS_QUEUE_NAMESPACE: "$(SB_NAMESPACE)"
     PAY_HUB_URL: "http://ccpay-bulkscanning-api-aat.service.core-compute-aat.internal"
     IDAM_API_URL: "https://idam-api.aat.platform.hmcts.net"

--- a/charts/bulk-scan-payment-processor/values.preview.template.yaml
+++ b/charts/bulk-scan-payment-processor/values.preview.template.yaml
@@ -11,7 +11,6 @@ java:
     PAYMENTS_QUEUE_ACCESS_KEY_LISTEN_NAME: "RootManageSharedAccessKey"
     PAYMENTS_QUEUE_ACCESS_KEY_SEND_NAME: "RootManageSharedAccessKey"
     PAYMENTS_QUEUE_READ_ACCESS_KEY: "$(SB_ACCESS_KEY)"
-    PAYMENTS_QUEUE_NAME: "payments-staging"
     PAYMENTS_QUEUE_NAMESPACE: "$(SB_NAMESPACE)"
     PAY_HUB_URL: "http://ccpay-bulkscanning-api-aat.service.core-compute-aat.internal"
     IDAM_API_URL: "https://idam-api.aat.platform.hmcts.net"

--- a/charts/bulk-scan-payment-processor/values.yaml
+++ b/charts/bulk-scan-payment-processor/values.yaml
@@ -6,6 +6,7 @@ java:
   environment:
     PAYMENTS_QUEUE_ACCESS_KEY_LISTEN_NAME: "ListenSharedAccessKey"
     PAYMENTS_QUEUE_MAX_DELIVERY_COUNT: "5"
+    PAYMENTS_QUEUE_NAME: payments
     PAYMENTS_QUEUE_NAMESPACE: bulk-scan-servicebus-{{ .Values.global.environment }}
     S2S_NAME: "bulk_scan_payment_processor"
     S2S_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,7 @@ azure:
       access-key: ${PAYMENTS_QUEUE_READ_ACCESS_KEY}
       access-key-name: ${PAYMENTS_QUEUE_ACCESS_KEY_LISTEN_NAME}
       namespace: ${PAYMENTS_QUEUE_NAMESPACE}
-      queue-name: payments
+      queue-name: ${PAYMENTS_QUEUE_NAME}
       max-delivery-count: ${PAYMENTS_QUEUE_MAX_DELIVERY_COUNT}
 
 pay-hub:


### PR DESCRIPTION
### Change description ###

There are no overrides in aat atm so not sure how it was not visible currently in aat fun tests (specifically namespace :shrug:). using this opportunity and finally applying staging queues the _same_ way it is done in other services

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
