### PR TITLE
FACT-1434 added launchdarkly to bulk-scan-payment-processor

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -18,7 +18,9 @@ def previewSecrets = [
     secret('s2s-secret-payment-processor', 'S2S_SECRET'),
     secret('idam-users-bulkscan-username', 'IDAM_USERS_BULKSCAN_USERNAME'),
     secret('idam-users-bulkscan-password', 'IDAM_USERS_BULKSCAN_PASSWORD'),
-    secret('idam-client-secret', 'IDAM_CLIENT_SECRET')
+    secret('idam-client-secret', 'IDAM_CLIENT_SECRET'),
+    secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+    secret('launch-darkly-offline-mode', 'LAUNCH_DARKLY_OFFLINE_MODE')
   ]
 ]
 
@@ -28,7 +30,9 @@ def nonPreviewSecrets = [
     secret('idam-users-bulkscan-username', 'IDAM_USERS_BULKSCAN_USERNAME'),
     secret('idam-users-bulkscan-password', 'IDAM_USERS_BULKSCAN_PASSWORD'),
     secret('idam-client-secret', 'IDAM_CLIENT_SECRET'),
-    secret('payments-staging-queue-send-shared-access-key', 'PAYMENTS_QUEUE_WRITE_ACCESS_KEY')
+    secret('payments-staging-queue-send-shared-access-key', 'PAYMENTS_QUEUE_WRITE_ACCESS_KEY'),
+    secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+    secret('launch-darkly-offline-mode', 'LAUNCH_DARKLY_OFFLINE_MODE')
   ]
 ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'checkstyle'
   id 'pmd'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.1.0'
+  id 'io.spring.dependency-management' version '1.1.3'
   id 'org.springframework.boot' version '2.7.17'
   id 'org.owasp.dependencycheck' version '8.3.1'
   id 'com.github.ben-manes.versions' version '0.47.0'
@@ -173,7 +173,7 @@ dependencyManagement {
       entry 'log4j-to-slf4j'
     }
     //CVE-2022-23181
-    dependencySet(group: 'org.apache.tomcat.embed', version: '11.0.0-M13') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.76') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-websocket'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ dependencyManagement {
       entry 'commons-io'
     }
     // CVE-2014-3488 CVE-2015-2156
-    dependencySet(group: 'io.netty', version: '2.0.62.Final') {
+    dependencySet(group: 'io.netty', version: '2.0.61.Final') {
       entry 'netty-tcnative-boringssl-static'
     }
     dependencySet(group: 'org.apache.logging.log4j', version: '2.20.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ dependencyManagement {
       entry 'commons-io'
     }
     // CVE-2014-3488 CVE-2015-2156
-    dependencySet(group: 'io.netty', version: '4.1.100.Final') {
+    dependencySet(group: 'io.netty', version: '2.0.62.Final') {
       entry 'netty-tcnative-boringssl-static'
     }
     dependencySet(group: 'org.apache.logging.log4j', version: '2.20.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.0'
-  id 'org.springframework.boot' version '2.7.14'
+  id 'org.springframework.boot' version '2.7.17'
   id 'org.owasp.dependencycheck' version '8.3.1'
   id 'com.github.ben-manes.versions' version '0.47.0'
   id 'org.sonarqube' version '4.2.1.3168'

--- a/build.gradle
+++ b/build.gradle
@@ -258,6 +258,8 @@ dependencies {
 
   implementation group: 'com.google.guava', name: 'guava', version: '32.1.0-jre'
 
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '6.2.1'
+
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.1.7'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ dependencyManagement {
       entry 'commons-io'
     }
     // CVE-2014-3488 CVE-2015-2156
-    dependencySet(group: 'io.netty', version: '2.0.61.Final') {
+    dependencySet(group: 'io.netty', version: '4.1.100.Final') {
       entry 'netty-tcnative-boringssl-static'
     }
     dependencySet(group: 'org.apache.logging.log4j', version: '2.20.0') {
@@ -173,7 +173,7 @@ dependencyManagement {
       entry 'log4j-to-slf4j'
     }
     //CVE-2022-23181
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.76') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '11.0.0-M13') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-websocket'
     }

--- a/charts/bulk-scan-payment-processor/Chart.yaml
+++ b/charts/bulk-scan-payment-processor/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: bspteam@hmcts.net
 dependencies:
   - name: java
-    version: 4.1.4
+    version: 5.0.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
     version: 1.0.4

--- a/charts/bulk-scan-payment-processor/Chart.yaml
+++ b/charts/bulk-scan-payment-processor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A helm chart for bulk scan pay processor app
 name: bulk-scan-payment-processor
 home: https://github.com/hmcts/bulk-scan-payment-processor
-version: 0.3.20
+version: 0.3.21
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/bulk-scan-payment-processor/values.preview.template.yaml
+++ b/charts/bulk-scan-payment-processor/values.preview.template.yaml
@@ -48,7 +48,7 @@ servicebus:
   teamName: "Software Engineering"
   location: uksouth
   serviceplan: basic
-  sbNamespace: bsp
+  sbNamespace: bsp-sb-preview
   setup:
     queues:
       - name: payments

--- a/charts/bulk-scan-payment-processor/values.yaml
+++ b/charts/bulk-scan-payment-processor/values.yaml
@@ -61,5 +61,9 @@ java:
           alias: idam.users.probate.username
         - name: idam-users-probate-password
           alias: idam.users.probate.password
+        - name: launch-darkly-sdk-key
+          alias: LAUNCH_DARKLY_SDK_KEY
+        - name: launch-darkly-offline-mode
+          alias: LAUNCH_DARKLY_OFFLINE_MODE
 servicebus:
   enabled: false

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2023-09-29">
+  <suppress until="2023-10-29">
         <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
         <cve>CVE-2023-35116</cve>
     </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,5 +3,5 @@
   <suppress until="2023-10-29">
         <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
         <cve>CVE-2023-35116</cve>
-    </suppress>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,4 +7,19 @@
   <suppress until="2023-10-29">
     <cve>CVE-2023-4586</cve>
   </suppress>
+  <suppress until="2023-11-05">
+    <cve>CVE-2023-44487</cve>
+  </suppress>
+  <suppress until="2023-11-05">
+    <cve>CVE-2023-42794</cve>
+  </suppress>
+  <suppress until="2023-11-05">
+    <cve>CVE-2023-41080</cve>
+  </suppress>
+  <suppress until="2023-11-05">
+    <cve>CVE-2023-42795</cve>
+  </suppress>
+  <suppress until="2023-11-05">
+    <cve>CVE-2023-45648</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2023-10-29">
+  <suppress until="2023-11-05">
         <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
         <cve>CVE-2023-35116</cve>
   </suppress>
-  <suppress until="2023-10-29">
+  <suppress until="2023-11-05">
     <cve>CVE-2023-4586</cve>
   </suppress>
   <suppress until="2023-11-05">

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,4 +4,7 @@
         <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
         <cve>CVE-2023-35116</cve>
   </suppress>
+  <suppress until="2023-10-29">
+    <cve>CVE-2023-4586</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2023-11-05">
+  <suppress until="2023-11-25">
         <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
         <cve>CVE-2023-35116</cve>
   </suppress>
-  <suppress until="2023-11-05">
+  <suppress until="2023-11-25">
     <cve>CVE-2023-4586</cve>
   </suppress>
-  <suppress until="2023-11-05">
+  <suppress until="2023-11-25">
     <cve>CVE-2023-44487</cve>
   </suppress>
-  <suppress until="2023-11-05">
+  <suppress until="2023-11-25">
     <cve>CVE-2023-42794</cve>
   </suppress>
-  <suppress until="2023-11-05">
+  <suppress until="2023-11-25">
     <cve>CVE-2023-41080</cve>
   </suppress>
-  <suppress until="2023-11-05">
+  <suppress until="2023-11-25">
     <cve>CVE-2023-42795</cve>
   </suppress>
-  <suppress until="2023-11-05">
+  <suppress until="2023-11-25">
     <cve>CVE-2023-45648</cve>
   </suppress>
 </suppressions>

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -114,3 +114,13 @@ data "azurerm_key_vault_secret" "appinsights_secret" {
   name         = "app-insights-instrumentation-key"
   key_vault_id = data.azurerm_key_vault.bulk_scan_key_vault.id
 }
+
+data "azurerm_key_vault_secret" "launch_darkly_sdk_key" {
+  name         = "launch-darkly-sdk-key"
+  key_vault_id = data.azurerm_key_vault.bulk_scan_key_vault.id
+}
+
+data "azurerm_key_vault_secret" "launch_darkly_offline_mode" {
+  name         = "launch-darkly-offline-mode"
+  key_vault_id = data.azurerm_key_vault.bulk_scan_key_vault.id
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/Flags.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/Flags.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.launchdarkly;
+
+public final class Flags {
+    private Flags() {
+
+    }
+
+    public static final String BULK_SCAN_PAYMENT_PROCESSOR_TEST = "bulk-scan-payment-processor-test";
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClient.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.launchdarkly;
+
+import com.launchdarkly.sdk.LDUser;
+import com.launchdarkly.sdk.server.interfaces.DataSourceStatusProvider;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LaunchDarklyClient {
+        public static final LDUser BULK_SCAN_PAYMENT_PROCESSOR_USER = new LDUser.Builder("bulk-scan-payment-processor")
+        .anonymous(true)
+        .build();
+
+    private final LDClientInterface internalClient;
+
+    @Autowired
+    public LaunchDarklyClient(
+        LaunchDarklyClientFactory launchDarklyClientFactory,
+        @Value("${launchdarkly.sdk-key:YYYYY}") String sdkKey,
+        @Value("${launchdarkly.offline-mode:false}") Boolean offlineMode
+    ) {
+        this.internalClient = launchDarklyClientFactory.create(sdkKey, offlineMode);
+    }
+
+    public boolean isFeatureEnabled(String feature) {
+        return internalClient.boolVariation(feature, LaunchDarklyClient.BULK_SCAN_PAYMENT_PROCESSOR_USER, false);
+    }
+
+    public boolean isFeatureEnabled(String feature, LDUser user) {
+        return internalClient.boolVariation(feature, user, false);
+    }
+
+    public DataSourceStatusProvider.Status getDataSourceStatus() {
+        return internalClient.getDataSourceStatusProvider().getStatus();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClient.java
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class LaunchDarklyClient {
-        public static final LDUser BULK_SCAN_PAYMENT_PROCESSOR_USER = new LDUser.Builder("bulk-scan-payment-processor")
-        .anonymous(true)
-        .build();
+    public static final LDUser BULK_SCAN_PAYMENT_PROCESSOR_USER = new LDUser.Builder("bulk-scan-payment-processor")
+            .anonymous(true)
+            .build();
 
     private final LDClientInterface internalClient;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClientFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClientFactory.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.launchdarkly;
+
+import com.launchdarkly.sdk.server.LDClient;
+import com.launchdarkly.sdk.server.LDConfig;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LaunchDarklyClientFactory {
+    public LDClientInterface create(String sdkKey, boolean offlineMode) {
+        LDConfig config = new LDConfig.Builder()
+            .offline(offlineMode)
+            .build();
+        return new LDClient(sdkKey, config);
+    }
+}

--- a/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/PaymentProcessorHealthTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/PaymentProcessorHealthTest.java
@@ -1,18 +1,19 @@
 package uk.gov.hmcts.reform.bulkscan.payment.processor;
 
-import com.typesafe.config.ConfigFactory;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@TestPropertySource("classpath:application.conf")
+@TestPropertySource("classpath:application.properties")
 class PaymentProcessorHealthTest {
 
-    private static final String TEST_URL = ConfigFactory.load().getString("test-url");
+    @Value("${test-url}")
+    private String TEST_URL;
 
     @Test
     void payment_processor_is_healthy() {

--- a/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/PaymentProcessorHealthTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/PaymentProcessorHealthTest.java
@@ -13,14 +13,14 @@ import static org.hamcrest.Matchers.equalTo;
 class PaymentProcessorHealthTest {
 
     @Value("${test-url}")
-    private String TEST_URL;
+    private String testUrl;
 
     @Test
     void payment_processor_is_healthy() {
         RestAssured
             .given()
             .relaxedHTTPSValidation()
-            .baseUri(TEST_URL)
+            .baseUri(testUrl)
             .get("/health")
             .then()
             .assertThat()

--- a/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/PaymentProcessorHealthTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/PaymentProcessorHealthTest.java
@@ -2,14 +2,17 @@ package uk.gov.hmcts.reform.bulkscan.payment.processor;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.hamcrest.Matchers.equalTo;
 
 @TestPropertySource("classpath:application.properties")
+@ExtendWith(SpringExtension.class)
 class PaymentProcessorHealthTest {
 
     @Value("${test-url}")

--- a/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/TestLaunchDarkly.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/payment/processor/TestLaunchDarkly.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor;
+
+import com.launchdarkly.sdk.server.interfaces.DataSourceStatusProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.launchdarkly.LaunchDarklyClient;
+import uk.gov.hmcts.reform.bulkscan.payment.processor.launchdarkly.LaunchDarklyClientFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.payment.processor.launchdarkly.Flags.BULK_SCAN_PAYMENT_PROCESSOR_TEST;
+
+@TestPropertySource("classpath:application.properties")
+@ExtendWith(SpringExtension.class)
+class TestLaunchDarkly {
+
+    @Value("${sdk-key}")
+    private String sdkKey;
+
+    @Value("${offline-mode}")
+    private Boolean offlineMode;
+
+    private LaunchDarklyClient ldClient;
+
+    @BeforeEach
+    void setUp() {
+        LaunchDarklyClientFactory ldFactory = new LaunchDarklyClientFactory();
+        ldClient = new LaunchDarklyClient(ldFactory, sdkKey, offlineMode);
+    }
+
+    @Test
+    void checkLaunchDarklyStatus() throws InterruptedException {
+
+        long startTime = System.currentTimeMillis();
+        long endTime = startTime + 60_000; // One minute in milliseconds
+
+        DataSourceStatusProvider.Status ldStatus;
+
+        do {
+            ldStatus = ldClient.getDataSourceStatus();
+            if (ldStatus.getState() == DataSourceStatusProvider.State.VALID) {
+                break; // Exit the loop if status is VALID
+            }
+            Thread.sleep(5_000); // Wait 5 seconds before polling again
+        } while (System.currentTimeMillis() < endTime);
+
+        assertThat(ldStatus.getState()).isEqualTo(DataSourceStatusProvider.State.VALID);
+    }
+
+    @Test
+    void checkLaunchDarklyTestFlag() {
+        Boolean testFeatureBoolean = ldClient.isFeatureEnabled(BULK_SCAN_PAYMENT_PROCESSOR_TEST);
+        assertThat(testFeatureBoolean).isTrue();
+        //BULK_SCAN_PAYMENT_PROCESSOR_TEST is a test flag only and needs to be set to TRUE within LD.
+    }
+}

--- a/src/smokeTest/resources/application.conf
+++ b/src/smokeTest/resources/application.conf
@@ -1,2 +1,0 @@
-test-url = "http://localhost:8583"
-test-url = ${?TEST_URL}

--- a/src/smokeTest/resources/application.properties
+++ b/src/smokeTest/resources/application.properties
@@ -1,0 +1,4 @@
+test-url=${TEST_URL:http://localhost:8581}
+
+offline-mode=${LAUNCH_DARKLY_OFFLINE_MODE:false}
+sdk-key=${LAUNCH_DARKLY_SDK_KEY:AAAAAAAAAAAAAAAA}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClientFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClientFactoryTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.launchdarkly;
+
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LaunchDarklyClientFactoryTest {
+    private LaunchDarklyClientFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new LaunchDarklyClientFactory();
+    }
+
+    @Test
+    void testCreate() throws IOException {
+        try (LDClientInterface client = factory.create("test key", true)) {
+            assertThat(client).isNotNull();
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClientTest.java
@@ -10,7 +10,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/payment/processor/launchdarkly/LaunchDarklyClientTest.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.reform.bulkscan.payment.processor.launchdarkly;
+
+import com.launchdarkly.sdk.LDUser;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LaunchDarklyClientTest {
+    private static final String SDK_KEY = "fake-key";
+    private static final String FAKE_FEATURE = "fake-feature";
+
+    @Mock
+    private LaunchDarklyClientFactory launchDarklyClientFactory;
+
+    @Mock
+    private LDClientInterface ldClient;
+
+    @Mock
+    private LDUser ldUser;
+
+    private LaunchDarklyClient launchDarklyClient;
+
+    @BeforeEach
+    void setUp() {
+        when(launchDarklyClientFactory.create(eq(SDK_KEY), anyBoolean())).thenReturn(ldClient);
+        launchDarklyClient = new LaunchDarklyClient(launchDarklyClientFactory, SDK_KEY, true);
+    }
+
+    @Test
+    void testFeatureEnabled() {
+        when(ldClient.boolVariation(eq(FAKE_FEATURE), any(LDUser.class), anyBoolean())).thenReturn(true);
+        assertTrue(launchDarklyClient.isFeatureEnabled(FAKE_FEATURE, ldUser));
+    }
+
+    @Test
+    void testFeatureDisabled() {
+        when(ldClient.boolVariation(eq(FAKE_FEATURE), any(LDUser.class), anyBoolean())).thenReturn(false);
+        assertFalse(launchDarklyClient.isFeatureEnabled(FAKE_FEATURE, ldUser));
+    }
+
+    @Test
+    void testFeatureEnabledWithoutUser() {
+        when(ldClient.boolVariation(eq(FAKE_FEATURE), any(LDUser.class), anyBoolean())).thenReturn(true);
+        assertTrue(launchDarklyClient.isFeatureEnabled(FAKE_FEATURE));
+    }
+
+    @Test
+    void testFeatureDisabledWithoutUser() {
+        when(ldClient.boolVariation(eq(FAKE_FEATURE), any(LDUser.class), anyBoolean())).thenReturn(false);
+        assertFalse(launchDarklyClient.isFeatureEnabled(FAKE_FEATURE));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-1434


### Change description ###
added launchdarkly to bulk-scan-payment-processor
changed existing smoke test to use different form of importing local keys

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
